### PR TITLE
refactor: padronização endpoint signup

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -28,7 +28,7 @@ router.get(
 router.post('/v1/login', new AuthController().login);
 
 router.post(
-  '/v1/signUp',
+  '/v1/signup',
   validationField,
   Validator,
   new UserController().create


### PR DESCRIPTION
Apesar de já seguir padrão REST, endpoint possuia letra maiúscula, o que não é uma boa prática, considerando consistência de padronização e possíveis problemas interoperabilidade. Alteração:

Antes:
```
router.post(
  '/v1/signUp',
  validationField,
  Validator,
  new UserController().create
);
```
Depois:
```
router.post(
  '/v1/signup',
  validationField,
  Validator,
  new UserController().create
);
```