### PR TITLE
feature/endpoint-retornar-favoritos

### DIFF
--- a/src/controller/CharacterController.ts
+++ b/src/controller/CharacterController.ts
@@ -614,22 +614,30 @@ export class CharacterController {
   /**
    * @swagger
    *
-   * /v1/favorite/{character_id}:
-   *   get:
+   * /v1/favorite:
+   *   post:
    *     summary: Favorita ou desfavorita um personagem especificado para o usuário corrente
    *     description: Se o personagem não tiver sido favoritado pelo usuário antes, uma entrada de favorito dele é criada.
    *                   Caso contrário, se o personagem já tiver sido favoritado anteriormente, sua entrada de favorito é removida.
    *     security:
    *       - BearerAuth: []
    *     tags: [Characters]
-   *     parameters:
-   *       - in: path
-   *         name: character_id
-   *         required: true
-   *         schema:
-   *           type: integer
-   *           minimum: 1
-   *         description: o ID do personagem
+   *     requestBody:
+   *       description: Envio do ID do personagem a ser favoritado/desfavoritado
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               character_id:
+   *                 type: number
+   *             example:
+   *               character_id: 1
+   *     consumes:
+   *       - application/json
+   *     produces:
+   *       - application/json
    *     responses:
    *       '200':
    *           description: 'Requisição bem sucedida.'
@@ -689,7 +697,7 @@ export class CharacterController {
    */
   async favoriteCharacter(req: Request, res: Response) {
     try {
-      const character_id: number = Number(req.params.character_id);
+      const character_id: number = Number(req.body.character_id);
       const user_id: number = req.body.user.id;
 
       const userRepository = MysqlDataSource.getRepository(User);

--- a/src/controller/CharacterController.ts
+++ b/src/controller/CharacterController.ts
@@ -470,6 +470,88 @@ export class CharacterController {
     }
   }
 
+  /**
+   * @swagger
+   *
+   * /v1/favorites:
+   *   get:
+   *
+   *     summary: Requisita página de favoritos do usuário
+   *     description: Retorna uma quantidade de 9 cards por página
+   *     security:
+   *       - BearerAuth: []
+   *     tags: [Characters]
+   *     parameters:
+   *       - in: query
+   *         name: page
+   *         required: false
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *         description: Página desejada
+   *       - in: query
+   *         name: search
+   *         required: false
+   *         schema:
+   *           type: string
+   *         description: Texto de busca especificado
+   *     responses:
+   *       '200':
+   *           description: 'Requisição bem sucedida.'
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   date:
+   *                     type: object
+   *                   status:
+   *                     type: boolean
+   *                   data:
+   *                     type: string
+   *                     description: 'objeto json de retorno'
+   *               example:
+   *                 date: {}
+   *                 status: true
+   *                 data: <ARRAY DE OBJETOS JSON>
+   *       '404':
+   *           description: 'Requisição falhou.'
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   date:
+   *                     type: object
+   *                   status:
+   *                     type: boolean
+   *                   data:
+   *                     type: string
+   *                     description: 'objeto json de retorno'
+   *               example:
+   *                 date: {}
+   *                 status: false
+   *                 data: "Página não encontrada."
+   *       '500':
+   *           description: 'Erro interno.'
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   date:
+   *                     type: object
+   *                   status:
+   *                     type: boolean
+   *                   data:
+   *                     type: string
+   *                     description: 'objeto json de retorno'
+   *               example:
+   *                 date: {}
+   *                 status: false
+   *                 data: "Um erro interno ocorreu."
+   *
+   */
   async getFavoritesPage(req: Request, res: Response) {
     try {
       const pageNumber: number = Number(req.query.page) || 1;

--- a/src/controller/CharacterController.ts
+++ b/src/controller/CharacterController.ts
@@ -564,6 +564,7 @@ export class CharacterController {
 
       const user_id: number = req.body.user.id;
 
+      //faz join de user_favorites e characters e pega apenas os personagens do usuário atual
       const found = MysqlDataSource.getRepository(UserFavorites)
         .createQueryBuilder('userFavorites')
         .innerJoinAndSelect('userFavorites.character', 'character')

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -24,6 +24,12 @@ router.post(
 router.get('/v1/check', new AuthController().confirmRegistration);
 
 router.get(
+  '/v1/favorites',
+  authenticateToken,
+  new CharacterController().getFavoritesPage
+);
+
+router.get(
   '/v1/favorite/:character_id',
   authenticateToken,
   new CharacterController().favoriteCharacter

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -29,8 +29,8 @@ router.get(
   new CharacterController().getFavoritesPage
 );
 
-router.get(
-  '/v1/favorite/:character_id',
+router.post(
+  '/v1/favorite',
   authenticateToken,
   new CharacterController().favoriteCharacter
 );


### PR DESCRIPTION
Criei esse novo endpoint **/v1/favorites** que retorna os personagens favoritados de cada usuário.

Houve uma certa repetição de lógica do endpoint **/v1/:category**, mas com algumas diferenças que acabei levando em conta na decisão de criar um endpoint diferente.

Gostaria de saber se esse modo é aceitável, ou se criar a categoria 'Favorites' e fazer uso apenas do endpoint **/v1/:category** é melhor. Tentei fazer isso, mas tive alguns problemas e decidi subir esse PR mesmo, dado o prazo da sprint.

Também fiz uma pequena alteração na rota de favoritar personagens, mudando-a para POST.

- Cria rota /v1/favorites

- Cria método getFavoritesPage semelhante ao getPage

- Rota de favoritar personagem **/v1/favorite** agora é POST