### PR TITLE
feat: adiciona job update survey database com pesquisas não respondidas

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "8.51.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-prettier": "5.0.1",
+    "date-fns": "2.30.0",
     "nodemon": "3.0.1",
     "ts-node": "10.9.1",
     "typedoc": "0.25.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,7 +14,7 @@ import { EmailSender } from './library/mail';
 import User from './entity/User';
 import Survey from './entity/Survey';
 import { categoriesArray } from './library/categoriesArray';
-import moment from 'moment';
+import { subDays, endOfDay } from 'date-fns';
 import { DeepPartial } from 'typeorm';
 
 MysqlDataSource.initialize()
@@ -42,11 +42,8 @@ cron.schedule('0 6 * * *', async function updateSurveyDatabase() {
    */
 
   try {
-    
-    const usageStartRangeTime = moment()
-      .subtract(15, 'days')
-      .endOf('day')
-      .toDate()
+    // data correspondente a 15 dias antes da data atual
+    const usageStartRangeTime = endOfDay(subDays(new Date(), 15));
 
     const dataForSurveyCreation = await userRepository
       .createQueryBuilder('users')

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -7,6 +7,7 @@ import {
   OneToMany
 } from 'typeorm';
 import Survey from './Survey';
+import UserAccessLog from './UserAccessLog';
 
 /**
  * Entidade com informações relacionadas a usuários da aplicação
@@ -36,6 +37,9 @@ export default class User {
 
   @OneToMany(() => Survey, (survey) => survey.user)
   surveys: Array<Survey>;
+
+  @OneToMany(() => UserAccessLog, (user_access_log) => user_access_log.user)
+  logins: Array<UserAccessLog>;
 
   @CreateDateColumn()
   createdAt: Date;


### PR DESCRIPTION
Esse PR implementa:
-  Adiciona job que lança diariamente pesquisas não respondidas para usuários:
   a) criados há pelo menos 15 dias, sem pesquisas respondias, cujo último login tem data igual ou superior ao dia em que estava apto a responder: 15 dias após a data de criação (para 1º pesquisa);
   b) cuja última pesquisa foi respondida há pelo menos 15 dias e último login tem data igual ou superior ao dia em que estava apto a responder: 15 dias após a data de realização da última pesquisa.
